### PR TITLE
fix/tag filtering fails with a postgreSQL database

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -22,11 +22,11 @@ class Product < ApplicationRecord
 	  where_stmt = ['lower(tags.value) LIKE ?'] * queries.size
   
 	  if assessed == '1'
-		includes(:tags, :scores).joins(:tags).group("products.id")
+		includes(:tags, :scores).joins(:tags).group("products.id, scores.id, tags.id")
 		  .where( where_stmt.join(' OR ') +' AND products.is_assessed = ? ', *queries, true)
 		  .paginate(page: page_index)
 	  else
-		includes(:tags, :scores).joins(:tags).group("products.id")
+		includes(:tags, :scores).joins(:tags).group("products.id, scores.id, tags.id")
 		  .where( where_stmt.join(' OR '), *queries)
 		  .paginate(page: page_index)
 	  end


### PR DESCRIPTION
This update to the `group by` clause is required for the tag-filtering functionality to work with a PostgreSQL data store (otherwise the result is a SQL error: `ERROR:  column "tags.id" must appear in the GROUP BY clause or be used in an aggregate function`). This change does not appear to affect functionality or correctness for SQLite-backed instances of the app.